### PR TITLE
fix std::map static assertion (for bullseye builds)

### DIFF
--- a/include/valijson/constraints/concrete_constraints.hpp
+++ b/include/valijson/constraints/concrete_constraints.hpp
@@ -913,7 +913,7 @@ public:
 private:
     typedef std::vector<const Subschema *, internal::CustomAllocator<const Subschema *>> Subschemas;
     typedef std::map<String, const Subschema *, std::less<String>,
-            internal::CustomAllocator<std::pair<String, const Subschema *>>> HintedSubschemas;
+            internal::CustomAllocator<std::pair<const String, const Subschema *>>> HintedSubschemas;
 
     /// Collection of sub-schemas, exactly one of which must be satisfied
     Subschemas m_subschemas;


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/container/map

C++ requires `const Key` in allocator, not `Key`. In Debian bullseye, STL now have static assertion about it, which breaks builds.