### PR TITLE
Fix build with gcc14

### DIFF
--- a/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h
+++ b/thirdparty/rapidjson-1.1.0/include/rapidjson/document.h
@@ -316,8 +316,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 
@@ -328,6 +326,8 @@ private:
     //! Disallow construction from non-const array
     template<SizeType N>
     GenericStringRef(CharType (&str)[N]) /* = delete */;
+    //! Copy assignment operator not permitted - immutable type
+    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
 };
 
 //! Mark a character pointer as constant string


### PR DESCRIPTION
rapidjson: remove non-compiling assignment operator
Backport https://github.com/Tencent/rapidjson/pull/719

```
thirdparty/rapidjson-1.1.0/include/rapidjson/document.h:319:82: error: assignment of read-only member 'rapidjson::GenericStringRef<CharType>::length'
 319 |     GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
     |                                                                           ~~~~~~~^~~~~~~~~~~~
```